### PR TITLE
Provide custom deletion for dag runs to speed up

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -165,7 +165,7 @@ class DagRun(Base, LoggingMixin):
     )
 
     task_instances = relationship(
-        TI, back_populates="dag_run", cascade="save-update, merge, delete, delete-orphan"
+        TI, back_populates="dag_run", cascade="save-update, merge, delete-orphan"
     )
     dag_model = relationship(
         "DagModel",

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -18,16 +18,20 @@
 from __future__ import annotations
 
 import json
+import logging
+import sys
 import textwrap
 import time
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence, List
 from urllib.parse import urlencode
 
 from flask import request, url_for
 from flask.helpers import flash
+from flask_appbuilder._compat import as_unicode
+from flask_appbuilder.const import LOGMSG_WAR_DBI_DEL_INTEGRITY, LOGMSG_ERR_DBI_DEL_GENERIC
 from flask_appbuilder.forms import FieldConverter
 from flask_appbuilder.models.filters import BaseFilter
-from flask_appbuilder.models.sqla import filters as fab_sqlafilters
+from flask_appbuilder.models.sqla import filters as fab_sqlafilters, Model
 from flask_appbuilder.models.sqla.filters import get_field_setup_query, set_value_to_type
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import lazy_gettext
@@ -37,6 +41,7 @@ from pendulum.datetime import DateTime
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
 from sqlalchemy import func, types
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.associationproxy import AssociationProxy
 
 from airflow.exceptions import RemovedInAirflow3Warning
@@ -58,6 +63,7 @@ if TYPE_CHECKING:
 
     from airflow.www.fab_security.sqla.manager import SecurityManager
 
+log = logging.getLogger(__name__)
 
 def datetime_to_string(value: DateTime | None) -> str | None:
     if value is None:
@@ -807,6 +813,63 @@ class CustomSQLAInterface(SQLAInterface):
 
     filter_converter_class = AirflowFilterConverter
 
+
+class DagRunCustomSQLAInterface(CustomSQLAInterface):
+    """
+        Overwrite of custom delete and delete_all methods for speeding up
+        the DagRun deletion when DagRun has a lot of task instances.
+        The default cascade deletion was performing very slowly when task instances were more than 10k.
+
+    """
+
+    def delete(self, item: Model, raise_exception: bool = False) -> bool:
+        try:
+            self._delete_files(item)
+            self.session.delete(item)
+            self.session.query(TaskInstance).where(TaskInstance.run_id == item.run_id).delete()
+            self.session.commit()
+            self.message = (as_unicode(self.delete_row_message), "success")
+            return True
+        except IntegrityError as e:
+            self.message = (as_unicode(self.delete_integrity_error_message), "warning")
+            log.warning(LOGMSG_WAR_DBI_DEL_INTEGRITY.format(str(e)))
+            self.session.rollback()
+            if raise_exception:
+                raise e
+            return False
+        except Exception as e:
+            self.message = (
+                as_unicode(self.general_error_message + " " + str(sys.exc_info()[0])),
+                "danger",
+            )
+            log.exception(LOGMSG_ERR_DBI_DEL_GENERIC.format(str(e)))
+            self.session.rollback()
+            if raise_exception:
+                raise e
+            return False
+
+    def delete_all(self, items: List[Model]) -> bool:
+        try:
+            for item in items:
+                self._delete_files(item)
+                self.session.delete(item)
+                self.session.query(TaskInstance).where(TaskInstance.run_id == item.run_id).delete()
+            self.session.commit()
+            self.message = (as_unicode(self.delete_row_message), "success")
+            return True
+        except IntegrityError as e:
+            self.message = (as_unicode(self.delete_integrity_error_message), "warning")
+            log.warning(LOGMSG_WAR_DBI_DEL_INTEGRITY.format(str(e)))
+            self.session.rollback()
+            return False
+        except Exception as e:
+            self.message = (
+                as_unicode(self.general_error_message + " " + str(sys.exc_info()[0])),
+                "danger",
+            )
+            log.exception(LOGMSG_ERR_DBI_DEL_GENERIC.format(str(e)))
+            self.session.rollback()
+            return False
 
 # This class is used directly (i.e. we can't tell Fab to use a different
 # subclass) so we have no other option than to edit the conversion table in

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4996,7 +4996,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
 
     route_base = "/dagrun"
 
-    datamodel = AirflowModelView.CustomSQLAInterface(models.DagRun)  # type: ignore
+    datamodel = wwwutils.DagRunCustomSQLAInterface(models.DagRun)  # type: ignore
 
     class_permission_name = permissions.RESOURCE_DAG_RUN
     method_permission_name = {


### PR DESCRIPTION
Provide custom deletion for dag runs to speed up when a dag run has a lot of related task instances

**Context:**
Solution is overwriting of custom delete and delete_all methods for speeding up the DagRun deletion when DagRun has a lot of task instances. The default cascade deletion was performing very slowly when task instances were more than 10k.


